### PR TITLE
FIX info-object version should be string

### DIFF
--- a/backend/swagger/api.yaml
+++ b/backend/swagger/api.yaml
@@ -4,7 +4,7 @@ info:
   title:
     A realworld microservices using AWS serverless backend
   description: A simplified implementation of AWS Serverless Application Repository
-  version: 2019-10-13
+  version: "2019-10-13"
 
 # Enable request validator. See doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-validation-sample-api-swagger.html
 x-amazon-apigateway-request-validators:
@@ -266,7 +266,7 @@ paths:
                 $ref: "#/components/schemas/InternalServerErrorException"
 
 components:
-  
+
   schemas:
     BadRequestException:
       type: object


### PR DESCRIPTION
I pasted the swagger into a [swagger editor](https://editor.swagger.io/) and it complained about `version` not being a string.
I looked up the [spec version 3.0.0](https://spec.openapis.org/oas/v3.0.0#info-object) and it says it should be a string as well.

The file is referenced from the AWS workshop: https://www.microservicesworkshop.com/starttheworkshop/atawsevent/createmicroservice.html